### PR TITLE
Changes how docker images are deleted

### DIFF
--- a/src/com/wolox/ProjectConfiguration.groovy
+++ b/src/com/wolox/ProjectConfiguration.groovy
@@ -1,5 +1,6 @@
 package com.wolox;
 
+import com.wolox.docker.DockerConfiguration;
 import com.wolox.steps.Steps;
 
 class ProjectConfiguration {
@@ -9,4 +10,6 @@ class ProjectConfiguration {
     def dockerfile;
     def projectName;
     def buildNumber;
+    DockerConfiguration dockerConfiguration;
+    def env;
 }

--- a/src/com/wolox/docker/DockerConfiguration.groovy
+++ b/src/com/wolox/docker/DockerConfiguration.groovy
@@ -1,0 +1,26 @@
+package com.wolox.docker;
+
+import com.wolox.ProjectConfiguration;
+
+class DockerConfiguration {
+
+    ProjectConfiguration projectConfiguration;
+
+    def imageName() {
+        "${reference()}:${tag()}".toLowerCase();
+    }
+
+    def baseName() {
+        "${projectConfiguration.projectName}".toLowerCase();
+    }
+
+    def  reference() {
+        def env = projectConfiguration.env;
+        "${baseName()}-${env.BRANCH_NAME}".toLowerCase();
+    }
+
+    def  tag() {
+        def env = projectConfiguration.env;
+        "${env.BUILD_ID}".toLowerCase();
+    }
+}

--- a/src/com/wolox/parser/ConfigParser.groovy
+++ b/src/com/wolox/parser/ConfigParser.groovy
@@ -1,15 +1,16 @@
 package com.wolox.parser;
 
 import com.wolox.ProjectConfiguration;
+import com.wolox.docker.DockerConfiguration;
 import com.wolox.services.*;
 import com.wolox.steps.*;
 
 class ConfigParser {
 
-    static ProjectConfiguration parse(def yaml, def buildNumber) {
+    static ProjectConfiguration parse(def yaml, def env) {
         ProjectConfiguration projectConfiguration = new ProjectConfiguration();
 
-        projectConfiguration.buildNumber = buildNumber;
+        projectConfiguration.buildNumber = env.BUILD_ID;
 
         // parse the environment variables
         projectConfiguration.environment    = parseEnvironment(yaml.environment);
@@ -25,6 +26,10 @@ class ConfigParser {
 
         // load the project name
         projectConfiguration.projectName = parseProjectName(yaml.config);
+
+        projectConfiguration.env = env;
+
+        projectConfiguration.dockerConfiguration = new DockerConfiguration(projectConfiguration: projectConfiguration);
 
         return projectConfiguration;
     }

--- a/vars/deleteDockerImages.groovy
+++ b/vars/deleteDockerImages.groovy
@@ -1,0 +1,13 @@
+@Library('wolox-ci')
+import com.wolox.*;
+
+def call(ProjectConfiguration projectConfig) {
+    def reference = projectConfig.dockerConfiguration.reference();
+    try {
+        sh "docker images --filter 'reference=${reference}*' --format \"{{.Tag}} {{.ID}}\" | sort -n | sed '\$d' | awk '{ print \$2 }' | xargs --no-run-if-empty docker rmi"
+
+    } catch(ignored) {
+        // this would make the entire popeline fail. We don't want that
+        println ignored
+    }
+}


### PR DESCRIPTION
## Summary
Docker images are named like this: `<project-name>:<build-number>`.

Each Pull request has it's own build number and therefore, with the existing naming conventions, we might have collisions.

In order to avoid collisions Images are now called like this: `<project-name>-<branch>:<build-number>`.