### PR TITLE
Add Repository:Tag to docker rmi

### DIFF
--- a/vars/deleteDockerImages.groovy
+++ b/vars/deleteDockerImages.groovy
@@ -4,7 +4,7 @@ import com.wolox.*;
 def call(ProjectConfiguration projectConfig) {
     def reference = projectConfig.dockerConfiguration.reference();
     try {
-        sh "docker images --filter 'reference=${reference}*' --format \"{{.Tag}} {{.ID}}\" | sort -n | sed '\$d' | awk '{ print \$2 }' | xargs --no-run-if-empty docker rmi -f"
+        sh "docker images --filter 'reference=${reference}*' --format \"{{.Tag}} {{.Repository}}:{{.Tag}}\" | sort -n | sed '\$d' | awk '{ print \$2 }' | xargs --no-run-if-empty docker rmi"
 
     } catch(ignored) {
         // this would make the entire popeline fail. We don't want that

--- a/vars/deleteDockerImages.groovy
+++ b/vars/deleteDockerImages.groovy
@@ -4,7 +4,7 @@ import com.wolox.*;
 def call(ProjectConfiguration projectConfig) {
     def reference = projectConfig.dockerConfiguration.reference();
     try {
-        sh "docker images --filter 'reference=${reference}*' --format \"{{.Tag}} {{.ID}}\" | sort -n | sed '\$d' | awk '{ print \$2 }' | xargs --no-run-if-empty docker rmi"
+        sh "docker images --filter 'reference=${reference}*' --format \"{{.Tag}} {{.ID}}\" | sort -n | sed '\$d' | awk '{ print \$2 }' | xargs --no-run-if-empty docker rmi -f"
 
     } catch(ignored) {
         // this would make the entire popeline fail. We don't want that


### PR DESCRIPTION
## Summary

Sometimes the cleanup command fails with `Error response from daemon: conflict: unable to delete 240aa2659704 (must be forced) - image is referenced in multiple repositories`. According to [this](https://github.com/meltwater/docker-cleanup/issues/19#issuecomment-282693536) specifying the repository and the tag should solve the problem.