### PR TITLE
Add docker tag support to services

### DIFF
--- a/src/com/wolox/parser/ConfigParser.groovy
+++ b/src/com/wolox/parser/ConfigParser.groovy
@@ -46,7 +46,7 @@ class ConfigParser {
         List<Step> steps = yamlSteps.collect { k, v ->
             Step step = new Step(name: k)
 
-            // a step can have one or more commands to execute    
+            // a step can have one or more commands to execute
             v.each {
                 step.commands.add(it);
             }
@@ -59,11 +59,14 @@ class ConfigParser {
         def services = [];
 
         steps.each {
-            def instance = getServiceClass(it.capitalize())?.newInstance()
-            services.add(instance)
+            def service = it.tokenize(':')
+            def version = service.size() == 2 ? service.get(1) : 'latest'
+            def instance = getServiceClass(service.get(0).capitalize())?.newInstance()
+
+            services.add([service: instance, version: version])
         };
 
-        services.add(new Base());
+        services.add([service: new Base(), version: 'latest']);
 
         return services
     }

--- a/src/com/wolox/parser/ConfigParser.groovy
+++ b/src/com/wolox/parser/ConfigParser.groovy
@@ -7,6 +7,8 @@ import com.wolox.steps.*;
 
 class ConfigParser {
 
+    private static String LATEST = 'latest';
+
     static ProjectConfiguration parse(def yaml, def env) {
         ProjectConfiguration projectConfiguration = new ProjectConfiguration();
 
@@ -60,13 +62,13 @@ class ConfigParser {
 
         steps.each {
             def service = it.tokenize(':')
-            def version = service.size() == 2 ? service.get(1) : 'latest'
+            def version = service.size() == 2 ? service.get(1) : LATEST
             def instance = getServiceClass(service.get(0).capitalize())?.newInstance()
 
             services.add([service: instance, version: version])
         };
 
-        services.add([service: new Base(), version: 'latest']);
+        services.add([service: new Base(), version: LATEST]);
 
         return services
     }

--- a/vars/base.groovy
+++ b/vars/base.groovy
@@ -1,7 +1,7 @@
 @Library('wolox-ci')
 import com.wolox.*;
 
-def call(ProjectConfiguration projectConfig, def nextClosure) {
+def call(ProjectConfiguration projectConfig, def _, def nextClosure) {
     return { variables ->
 
         withEnv(projectConfig.environment) {

--- a/vars/mssql.groovy
+++ b/vars/mssql.groovy
@@ -1,11 +1,11 @@
 @Library('wolox-ci')
 import com.wolox.*;
 
-def call(ProjectConfiguration projectConfig, def nextClosure) {
+def call(ProjectConfiguration projectConfig, def version, def nextClosure) {
     return { variables ->
         def dbPassword = 'someReallyStrongPwd123'
         /* Build mssql image */
-        docker.image('microsoft/mssql-server-linux').withRun("-e \"ACCEPT_EULA=Y\" -e \"SA_PASSWORD=${dbPassword}\"") { db ->
+        docker.image("microsoft/mssql-server-linux:${version}").withRun("-e \"ACCEPT_EULA=Y\" -e \"SA_PASSWORD=${dbPassword}\"") { db ->
             withEnv(['DB_USERNAME=sa', "DB_PASSWORD=${dbPassword}", "DB_HOST=db", "DB_PORT=1433"]) {
                 variables.db = db;
                 nextClosure(variables)

--- a/vars/postgres.groovy
+++ b/vars/postgres.groovy
@@ -1,10 +1,10 @@
 @Library('wolox-ci')
 import com.wolox.*;
 
-def call(ProjectConfiguration projectConfig, def nextClosure) {
+def call(ProjectConfiguration projectConfig, def version, def nextClosure) {
     return { variables ->
         /* Build postgres image */
-        docker.image('postgres').withRun() { db ->
+        docker.image("postgres:${version}").withRun() { db ->
             withEnv(['DB_USERNAME=postgres', 'DB_PASSWORD=', "DB_HOST=db", "DB_PORT=5432"]) {
                 variables.db = db;
                 nextClosure(variables)

--- a/vars/redis.groovy
+++ b/vars/redis.groovy
@@ -1,10 +1,10 @@
 @Library('wolox-ci')
 import com.wolox.*;
 
-def call(ProjectConfiguration projectConfig, def nextClosure) {
+def call(ProjectConfiguration projectConfig, def version, def nextClosure) {
     return { variables ->
         /* Build redis image */
-        docker.image('redis').withRun() { redis ->
+        docker.image("redis:${version}").withRun() { redis ->
             withEnv(["REDIS_URL=redis://redis"]) {
                 variables.redis = redis;
                 nextClosure(variables)

--- a/vars/woloxCi.groovy
+++ b/vars/woloxCi.groovy
@@ -21,7 +21,7 @@ def call(String yamlName) {
     // each service is a closure that when called it executes its logic and then calls a closure, the next step.
     projectConfig.services.each {
 
-        closure = "${it.getVar()}"(projectConfig, closure);
+        closure = "${it.service.getVar()}"(projectConfig, it.version, closure);
     }
 
     // we execute the top level closure so that the cascade starts.


### PR DESCRIPTION
### Summary

Now we can set the desired docker image version/tag of the listed services, e.g.
```
services:
  - postgres:9.6
  - redis
```

This will use `postgres:9.6` and `redis:latest` images.
