### PR TITLE
Add Elasticsearch service

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ When listing `mongo` as a service, this will build a docker image from [`mongo`]
 3. DB_HOST
 4. DB_PORT
 
+### Elasticsearch
+
+When listing `elasticsearch:6.4.0` as a service (it's mandatory specify the image version), this will build a docker image from [`elasticsearch`](https://www.docker.elastic.co/) exposing the following environment variables:
+
+1. ELASTICSEARCH_URL
+
 ## Steps
 
 This section lets you define the steps you need to build your project. Each level inside the `steps` section is a stage in the Jenkins pipeline and each item in the stage is a command to run. In the case above, there are 5 stages named:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ environment:
   GIT_COMMITTER_NAME: a
   GIT_COMMITTER_EMAIL: b
   LANG: C.UTF-8
+
+timeout: 600
 ```
 
 This file has different sections:
@@ -130,3 +132,7 @@ The analysis stage, for example, runs the following commands:
 ## Environment
 
 This section lets you set up custom environment variables. Each item inside this section defines a variable with its value.
+
+## Timeout
+
+This section lets you set up a custom timeout in seconds. The default is 600 (10 minutes).

--- a/src/com/wolox/ProjectConfiguration.groovy
+++ b/src/com/wolox/ProjectConfiguration.groovy
@@ -12,4 +12,5 @@ class ProjectConfiguration {
     def buildNumber;
     DockerConfiguration dockerConfiguration;
     def env;
+    def timeout;
 }

--- a/src/com/wolox/parser/ConfigParser.groovy
+++ b/src/com/wolox/parser/ConfigParser.groovy
@@ -8,6 +8,7 @@ import com.wolox.steps.*;
 class ConfigParser {
 
     private static String LATEST = 'latest';
+    private static Integer DEFAULT_TIMEOUT = 600;   // 600 seconds
 
     static ProjectConfiguration parse(def yaml, def env) {
         ProjectConfiguration projectConfiguration = new ProjectConfiguration();
@@ -32,6 +33,8 @@ class ConfigParser {
         projectConfiguration.env = env;
 
         projectConfiguration.dockerConfiguration = new DockerConfiguration(projectConfiguration: projectConfiguration);
+
+        projectConfiguration.timeout = yaml.timeout ?: DEFAULT_TIMEOUT;
 
         return projectConfiguration;
     }

--- a/src/com/wolox/parser/ConfigParser.groovy
+++ b/src/com/wolox/parser/ConfigParser.groovy
@@ -74,6 +74,7 @@ class ConfigParser {
     }
 
     static def getServiceClass(def name) {
+        // TODO: Refactor this
         switch(name) {
             case "Postgres":
                 return Postgres
@@ -89,6 +90,9 @@ class ConfigParser {
                 break
             case "Mongodb":
                 return Mongodb
+                break
+            case "Elasticsearch":
+                return Elasticsearch
                 break
         }
     }

--- a/src/com/wolox/services/Elasticsearch.groovy
+++ b/src/com/wolox/services/Elasticsearch.groovy
@@ -1,0 +1,7 @@
+package com.wolox.services;
+
+class Elasticsearch {
+    def getVar() {
+        return "elasticsearch"
+    }
+}

--- a/vars/base.groovy
+++ b/vars/base.groovy
@@ -3,8 +3,7 @@ import com.wolox.*;
 
 def call(ProjectConfiguration projectConfig, def _, def nextClosure) {
     return { variables ->
-        def timeoutTime = projectConfig.env.TIMEOUT ?: 600 // timeout 10 minutes
-        timeout(time: timeoutTime, unit: 'SECONDS') {
+        timeout(time: projectConfig.timeout, unit: 'SECONDS') {
             withEnv(projectConfig.environment) {
                 wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
                     nextClosure(variables)

--- a/vars/elasticsearch.groovy
+++ b/vars/elasticsearch.groovy
@@ -1,0 +1,14 @@
+@Library('wolox-ci')
+import com.wolox.*;
+
+def call(ProjectConfiguration projectConfig, def version, def nextClosure) {
+    return { variables ->
+        /* Build elasticsearch image */
+        docker.image("docker.elastic.co/elasticsearch/elasticsearch:${version}").withRun("-p 9200:9200 -p 9300:9300 -e \"discovery.type=single-node\"") { elasticsearch ->
+            withEnv(["ELASTICSEARCH_URL=http://elasticsearch:9200"]) {
+                variables.elasticsearch = elasticsearch;
+                nextClosure(variables)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Elasticsearch service
- Change how the timeout is handled. We were fetching it from Jenkins environment variables, instead of from the YAML. Now we have a custom key in the YAML to set the timeout (if not set, it will default to 600 seconds).