### PR TITLE
Support postgres:12.2 with auth 'trust'

### DIFF
--- a/vars/postgres.groovy
+++ b/vars/postgres.groovy
@@ -4,7 +4,7 @@ import com.wolox.*;
 def call(ProjectConfiguration projectConfig, def version, def nextClosure) {
     return { variables ->
         /* Build postgres image */
-        docker.image("postgres:12.1").withRun() { db ->
+        docker.image("postgres:${version}").withRun('-e POSTGRES_HOST_AUTH_METHOD=trust') { db ->
             withEnv(['DB_USERNAME=postgres', 'DB_PASSWORD=', "DB_HOST=db", "DB_PORT=5432"]) {
                 variables.db = db;
                 nextClosure(variables)


### PR DESCRIPTION
Behavior changed in postgres:12.2, now it is required to either set up
a password for the postgres superuser or to force the auth method to be
'trust'. Since we're running this in a CI and databases are volatile
here either way I chose the 'trust' version.

See https://github.com/docker-library/postgres/commit/42ce7437ee68150ee29f5272428aa4fc657dc6dc
for the commit on the postgres image side.