### PR TITLE
fix environment parsing issue when no environment has been provided & add a cleanup stage to remove the cleanup steps the latest user-defined steps

### DIFF
--- a/src/com/wolox/parser/ConfigParser.groovy
+++ b/src/com/wolox/parser/ConfigParser.groovy
@@ -41,7 +41,7 @@ class ConfigParser {
 
     static def parseEnvironment(def environment) {
         if (!environment) {
-            return "";
+            return [];
         }
 
         return environment.collect { k, v -> "${k}=${v}"};

--- a/vars/woloxCi.groovy
+++ b/vars/woloxCi.groovy
@@ -28,6 +28,8 @@ def call(String yamlName) {
     try {
         closure([:]);
     } finally{
-        deleteDockerImages(projectConfig);
+        stage("cleanup") {
+            deleteDockerImages(projectConfig);
+        }
     }
 }


### PR DESCRIPTION
Thanks for the amazing yet simple yaml pipeline on top of jenkines!

I found this issue and I am happy to send a PR, it contains the following:

* fix the issue of passing empty string instead of an array in case of empty environment array. this issue causes the base var to break if no environment was set
* add a cleanup stage to remove the cleanup steps the latest user-defined steps